### PR TITLE
Clamp x3 between x1 and x2 in modab_modern_impl.pyx

### DIFF
--- a/modab_root_finder/modab_modern_impl.pyx
+++ b/modab_root_finder/modab_modern_impl.pyx
@@ -37,12 +37,14 @@ cdef double midpoint(Node p1, Node p2):
 
 cdef double secant(Node p1, Node p2):
     x3 = (p1.x * p2.y - p1.y * p2.x) / (p2.y - p1.y)
-    # Clamp x3 between x1 and x2. If the function is very flat and p2.y is close p1.y, floating point rounding errors can shoot x3 outside the bracketing interval
-    if x3 < x1:
-        return x1
-    elif x3 > x2:
-        return x2
+    # Clamp x3 between x1 and x2. If the function is very flat and p2.y is close to
+    # p1.y, floating point rounding errors can shoot x3 outside the bracketing interval
+    if x3 < p1.x:
+        return p1.x
+    elif x3 > p2.x:
+        return p2.x
     return x3
+
 
 cdef tuple initialize(F, double x1, double x2, double eps_f):
     p1 = Node()

--- a/modab_root_finder/modab_modern_impl.pyx
+++ b/modab_root_finder/modab_modern_impl.pyx
@@ -36,8 +36,13 @@ cdef double midpoint(Node p1, Node p2):
 
 
 cdef double secant(Node p1, Node p2):
-    return (p1.x * p2.y - p1.y * p2.x) / (p2.y - p1.y)
-
+    x3 = (p1.x * p2.y - p1.y * p2.x) / (p2.y - p1.y)
+    # Clamp x3 between x1 and x2. If the function is very flat and p2.y is close p1.y, floating point rounding errors can shoot x3 outside the bracketing interval
+    if x3 < x1:
+        return x1
+    elif x3 > x2:
+        return x2
+    return x3
 
 cdef tuple initialize(F, double x1, double x2, double eps_f):
     p1 = Node()

--- a/modab_root_finder/modab_modern_impl.pyx
+++ b/modab_root_finder/modab_modern_impl.pyx
@@ -197,3 +197,18 @@ cpdef modab_modern_impl(F, double x1, double x2, double eps_f, int maxiter=1000)
             side = 0
 
     raise Exception("failed to converge!")
+
+
+# Testing wrappers
+def _secant(double x1, double y1, double x2, double y2):
+    p1 = Node()
+    p1.x = x1
+    p1.y = y1
+    p2 = Node()
+    p2.x = x2
+    p2.y = y2
+    return secant(p1, p2)
+
+
+def _sign(double x):
+    return sign(x)

--- a/modab_root_finder/modab_modern_impl.pyx
+++ b/modab_root_finder/modab_modern_impl.pyx
@@ -4,6 +4,7 @@
 import cython
 import os
 import math
+from libc.math cimport isnan, NAN
 
 cdef bint debug = bool(int(os.environ.get('MODAB_MOD_DEBUG', '0')))
 cdef bint enable_prev_x_check = False
@@ -43,6 +44,8 @@ cdef double secant(Node p1, Node p2):
         return p1.x
     elif x3 > p2.x:
         return p2.x
+    elif isnan(x3):
+        return p1.x
     return x3
 
 

--- a/modab_root_finder/tests/test_modern.py
+++ b/modab_root_finder/tests/test_modern.py
@@ -1,0 +1,47 @@
+from modab_root_finder import root_scalar
+from modab_root_finder.modab_modern_impl import (
+    _secant,
+    _sign,
+)
+from numpy.testing import assert_allclose
+import pytest
+from hypothesis import given, strategies as st, assume, settings
+
+
+def test_secant():
+    actual = _secant(x1=-1, y1=2, x2=1, y2=-1)
+    expected = 0.33333333333
+    assert_allclose(actual, expected)
+
+
+def test_secant_zerodiv():
+    with pytest.raises(ZeroDivisionError):
+        actual = _secant(x1=-1, y1=0, x2=1, y2=0)
+
+
+
+def test_secant_overflow():
+    # https://github.com/nickodell/modab_root_finder/pull/2
+    x1 = 0.0
+    x2 = 1e15
+    x3 = _secant(
+        x1=x1,
+        y1=-1e+300,
+        x2=x2,
+        y2=1e+300,
+    )
+    assert x1 <= x3 <= x2
+
+
+@given(
+    x1=st.floats(max_value=0),
+    y1=st.floats(),
+    x2=st.floats(min_value=0),
+    y2=st.floats(),
+)
+@settings(max_examples=1000)
+def test_secant_fuzz(x1, y1, x2, y2):
+    assume(x1 < x2)
+    assume(_sign(y1) != _sign(y2))
+    x3 = _secant(x1, y1, x2, y2)
+    assert x1 <= x3 <= x2, f"Expected x3 to lie within [x1, x2]. {x1=} {x2=} {x3=}"


### PR DESCRIPTION
Clamp x3 between x1 and x2. If the function is very flat and p2.y is close p1.y, floating point rounding errors can shoot x3 outside the bracketing interval